### PR TITLE
feat: add admin default setting for “Create money”

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -49,4 +49,7 @@ return [
 
     (new Extend\ApiController(ShowDiscussionController::class))
         ->addInclude('posts.moneyRewards.giver'),
+
+    (new Extend\Settings())
+        ->serializeToForum('moneyRewardsCreateMoneyByDefault', 'money-rewards.createMoneyByDefault'),
 ];

--- a/js/src/admin/index.ts
+++ b/js/src/admin/index.ts
@@ -4,6 +4,12 @@ app.initializers.add('clarkwinkelmann-money-rewards', () => {
     app.extensionData
         .for('clarkwinkelmann-money-rewards')
         .registerSetting({
+            type: 'switch',
+            setting: 'money-rewards.createMoneyByDefault',
+            label: app.translator.trans('clarkwinkelmann-money-rewards.admin.settings.createMoneyByDefault'),
+            min: 0,
+        })
+        .registerSetting({
             type: 'text',
             setting: 'money-rewards.preselection',
             label: app.translator.trans('clarkwinkelmann-money-rewards.admin.settings.preselection'),

--- a/js/src/forum/components/RewardModal.ts
+++ b/js/src/forum/components/RewardModal.ts
@@ -1,8 +1,8 @@
 import app from 'flarum/forum/app';
-import Modal, {IInternalModalAttrs} from 'flarum/common/components/Modal';
+import Modal, { IInternalModalAttrs } from 'flarum/common/components/Modal';
 import Button from 'flarum/common/components/Button';
 import Switch from 'flarum/common/components/Switch';
-import {ApiPayloadSingle} from 'flarum/common/Store';
+import { ApiPayloadSingle } from 'flarum/common/Store';
 import Post from 'flarum/common/models/Post';
 import FormattedMoney from './FormattedMoney';
 
@@ -16,10 +16,14 @@ export default class RewardModal extends Modal<RewardModalAttrs> {
     customAmountValue: string = ''
     createMoney: boolean = false
     comment: string = ''
+    loading: boolean = false
 
     oninit(vnode: any) {
         super.oninit(vnode);
 
+        this.createMoney =
+            app.forum.attribute('moneyRewardsCreateMoney') &&
+            app.forum.attribute('moneyRewardsCreateMoneyByDefault') == 1;
         if ((app.forum.attribute<string[]>('moneyRewardsPreselection') || []).length === 0) {
             this.customAmount = true;
         }
@@ -35,6 +39,7 @@ export default class RewardModal extends Modal<RewardModalAttrs> {
 
     content() {
         const preselection = app.forum.attribute<string[]>('moneyRewardsPreselection') || [];
+        const canCreateMoney = !!app.forum.attribute('moneyRewardsCreateMoney');
 
         return m('.Modal-body', [
             m('.Form-group', [
@@ -94,7 +99,7 @@ export default class RewardModal extends Modal<RewardModalAttrs> {
                     })
                 }),
             ]),
-            app.forum.attribute('moneyRewardsCreateMoney') ? m('.Form-group', [
+            canCreateMoney ? m('.Form-group', [
                 Switch.component({
                     state: this.createMoney,
                     onchange: (value: boolean) => {
@@ -122,32 +127,34 @@ export default class RewardModal extends Modal<RewardModalAttrs> {
     onsubmit(event: Event) {
         event.preventDefault();
 
-        this.loading = true;
+        if (!this.loading) {
+            this.loading = true;
 
-        app.request<ApiPayloadSingle>({
-            method: 'POST',
-            url: app.forum.attribute('apiUrl') + '/posts/' + this.attrs.post.id() + '/money-rewards',
-            errorHandler: this.onerror.bind(this),
-            body: {
-                data: {
-                    attributes: {
-                        amount: this.customAmount ? this.customAmountValue : app.forum.attribute<string[]>('moneyRewardsPreselection')[this.preselectAmount],
-                        createMoney: this.createMoney,
-                        comment: this.comment,
+            app.request<ApiPayloadSingle>({
+                method: 'POST',
+                url: app.forum.attribute('apiUrl') + '/posts/' + this.attrs.post.id() + '/money-rewards',
+                errorHandler: this.onerror.bind(this),
+                body: {
+                    data: {
+                        attributes: {
+                            amount: this.customAmount ? this.customAmountValue : app.forum.attribute<string[]>('moneyRewardsPreselection')[this.preselectAmount],
+                            createMoney: !!app.forum.attribute('moneyRewardsCreateMoney') && this.createMoney,
+                            comment: this.comment,
+                        },
                     },
                 },
-            },
-        })
-            .then(payload => {
-                app.store.pushPayload(payload);
-
-                this.hide();
-
-                app.alerts.show({type: 'success'}, app.translator.trans('clarkwinkelmann-money-rewards.forum.modal.success'));
             })
-            .catch(() => {
-                this.loading = false;
-                m.redraw();
-            });
+                .then(payload => {
+                    app.store.pushPayload(payload);
+
+                    this.hide();
+
+                    app.alerts.show({ type: 'success' }, app.translator.trans('clarkwinkelmann-money-rewards.forum.modal.success'));
+                })
+                .catch(() => {
+                    this.loading = false;
+                    m.redraw();
+                });
+        }
     }
 }

--- a/locale/en.yml
+++ b/locale/en.yml
@@ -5,6 +5,7 @@ clarkwinkelmann-money-rewards:
             min: Minimum value for custom amounts
             max: Maximum value for custom amounts
             decimals: Maximum number of decimals for custom amounts
+            createMoneyByDefault: Enable "Create money" by default
         permissions:
             seeMoneyRewardHistory: See history of other user's rewards
             rewardWithMoney: Reward other users with money


### PR DESCRIPTION
This PR adds an admin setting so forums can open the money reward modal with “Create money” turned on by default when that feature is allowed.